### PR TITLE
Fix UPF_RUNCONFIG env variable

### DIFF
--- a/deploy_upf/upf-c-deploy.yaml
+++ b/deploy_upf/upf-c-deploy.yaml
@@ -29,7 +29,7 @@ spec:
           securityContext:
             privileged: true
           env:
-          - name: UPU_RUNCONFIG
+          - name: UPF_RUNCONFIG
             value: /opt/upf/config/smu/smu_docker.ini
           command: [ "/opt/upf/bin/smu" ]    # Start the program
           stdin: true

--- a/deploy_upf/upf-loadbalancer.yaml
+++ b/deploy_upf/upf-loadbalancer.yaml
@@ -30,7 +30,7 @@ spec:
             capabilities:
               add: ["IPC_LOCK"]
           env:
-          - name: UPU_RUNCONFIG
+          - name: UPF_RUNCONFIG
             value: /opt/upf/config/lbu/lbu_docker.ini
           - name: DPDK_PCIDEVICE
             value: PCIDEVICE_INTEL_COM_INTEL_SRIOV_DPDK   #delimited by comma, for example A,B

--- a/deploy_upf/upf-u-deploy.yaml
+++ b/deploy_upf/upf-u-deploy.yaml
@@ -46,7 +46,7 @@ spec:
           capabilities:
             add: ["IPC_LOCK"]
         env:
-        - name: UPU_RUNCONFIG
+        - name: UPF_RUNCONFIG
           value: /opt/upf/config/fpu/fpu_docker.ini
         - name: DPDK_PCIDEVICE
           value: PCIDEVICE_INTEL_COM_INTEL_SRIOV_DPDK   #delimited by comma, for example A,B


### PR DESCRIPTION
**_UPU_RUNCONFIG_** should be **_UPF_RUNCONFIG_** in the upf-c, upf-u and upf-loadbalancer manifests.

Signed-off-by: Christopher Adigun <futuredon@gmail.com>